### PR TITLE
Product variation : allowing to use `value` arg

### DIFF
--- a/wpuwooproductfields.php
+++ b/wpuwooproductfields.php
@@ -201,7 +201,7 @@ class WPUWooProductFields {
 
             $field['name'] = $field['no_prefix_meta'] ? $id : '_' . $id . '[' . $variation->ID . ']';
             $field['id'] = $field['no_prefix_meta'] ? $id : '_' . $id . '_' . $variation->ID . '_';
-            $field['value'] = get_post_meta($variation->ID, $field['no_prefix_meta'] ? '' . $id : '_' . $id, true);
+            $field['value'] = $field['value'] = isset($field['value']) ? $field['value'] : get_post_meta($variation->ID, $field['no_prefix_meta'] ? '' . $id : '_' . $id, true);
             if (isset($field['separator_before']) && $field['separator_before']) {
                 echo '</div><div class="form-row form-row-full">';
             } else if (isset($field['separator_border_before']) && $field['separator_border_before']) {


### PR DESCRIPTION
Hi @Darklg,

I noticed that it wasn't possible to use the `value` argument when creating a new field.
Is there a specific reason for this behavior ?

I made a simple change to allow the use of the argument `value`, like bellow.
```php
$values['sub_more_info'] = array(
    'variation' => 'attribute_pa_conference_datetime',
    'type' => 'text',
    'label' => __('Informations complémentaires', 'beauxarts'),
    'value' => 'Le nombre de place est limité.',
  );
```